### PR TITLE
Add:育成論投稿ボタンを押した時、計算画面に遷移するようにuseNavigateを追加 #88

### DIFF
--- a/frontend/src/pages/NewPost.jsx
+++ b/frontend/src/pages/NewPost.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import Select from "react-select";
 import "../css/NewPost.css";
@@ -71,6 +72,8 @@ const all_types = [
 ];
 
 const NewPost = () => {
+  const navigate = useNavigate();
+
   const [title, setTitle] = useState(null);
   const [body, setBody] = useState(null);
   const [pokemon, setPokemon] = useState(null);
@@ -152,7 +155,7 @@ const NewPost = () => {
     setEvSpeed(event.target.value);
   };
 
-  // tokenを取得
+  // tokenを取得（クライアント側でtokenを保存する処理を行なっていないので、都度firebaseから取得する必要あり)
   const { currentUser } = useAuthContext();
   async function setConfig() {
     const token = await currentUser?.getIdToken();
@@ -226,6 +229,7 @@ const NewPost = () => {
       console.log(response.data);
       if (response.status === 200) {
         toast.success("育成論が投稿されました!");
+        navigate("/");
         return response.data;
       }
     } catch (err) {


### PR DESCRIPTION
Why
重複投稿を防ぐ+直感的なUIにするため
What
useNavigateを用い、投稿成功時に計算画面にリダイレクト